### PR TITLE
ENH: Enabled option to allow client to choose OpenCL vendor implementation

### DIFF
--- a/include/ovrvision_pro.h
+++ b/include/ovrvision_pro.h
@@ -144,10 +144,11 @@ public:
 	/*!	@brief Open the Ovrvision Pro
 		@param locationID Connection number
 		@param prop Camera property
+		@param pVendorName c style string with the vendor name ("NVIDIA Corporation", "Intel(R) Corporation", )
         @param deviceType (2:D3D11, 0:OpenGL, -1:Dont share)
 		@param pD3D11Device ptr to D3D11 device when deviceType == 2
 		@return If successful, the return value is 0< */
-	int Open(int locationID, OVR::Camprop prop, int deviceType = -1, void *pD3D11Device = NULL);
+	int Open(int locationID, OVR::Camprop prop, const char *pVendorName = NULL, int deviceType = -1, void *pD3D11Device = NULL);
 	/*!	@brief Close the Ovrvision Pro */
 	void Close();
 

--- a/src/lib_src/OvrvisionProCL.h
+++ b/src/lib_src/OvrvisionProCL.h
@@ -128,8 +128,9 @@ namespace OVR
                 @param width of image
                 @param height of image
                 @param mode of sharing with D3D11 or OpenGL 
-                @param pDevice for D3D11 */
-			OvrvisionProOpenCL(int width, int height, enum SHARING_MODE mode = NONE, void *pDevice = NULL);
+                @param pDevice for D3D11 
+                @param pVendorID for requesting GPU from given vendor*/
+			OvrvisionProOpenCL(int width, int height, enum SHARING_MODE mode = NONE, void *pDevice = NULL, const char *platform = NULL);
 			~OvrvisionProOpenCL();
 
 			/*! @brief release resources */

--- a/src/lib_src/ovrvision_pro.cpp
+++ b/src/lib_src/ovrvision_pro.cpp
@@ -83,7 +83,7 @@ OvrvisionPro::~OvrvisionPro()
 
 //Initialize
 //Open the Ovrvision
-int OvrvisionPro::Open(int locationID, OVR::Camprop prop, int deviceType, void *pDevice)
+int OvrvisionPro::Open(int locationID, OVR::Camprop prop, const char *pVendorName, int deviceType, void *pDevice)
 {
 	int objs = 0;
 	int challenge;
@@ -195,15 +195,15 @@ int OvrvisionPro::Open(int locationID, OVR::Camprop prop, int deviceType, void *
 	try {
 		if (deviceType == 2 && pDevice != NULL)
 		{
-			m_pOpenCL = new OvrvisionProOpenCL(cam_width, cam_height, D3D11, pDevice); // When use D3D11 sharing texture
+			m_pOpenCL = new OvrvisionProOpenCL(cam_width, cam_height, D3D11, pDevice, pVendorName); // When use D3D11 sharing texture
 		}
 		else if (deviceType == 0)
 		{
-			m_pOpenCL = new OvrvisionProOpenCL(cam_width, cam_height, OPENGL);    // When use OpenGL sharing texture
+			m_pOpenCL = new OvrvisionProOpenCL(cam_width, cam_height, OPENGL, NULL, pVendorName);    // When use OpenGL sharing texture
 		}
 		else
 		{
-			m_pOpenCL = new OvrvisionProOpenCL(cam_width, cam_height);
+			m_pOpenCL = new OvrvisionProOpenCL(cam_width, cam_height, NONE, NULL, pVendorName);
 		}
     }
 	catch (std::exception ex)


### PR DESCRIPTION
Forwarding the requested vendor name to the SelectGPU function

Vendor name is optional, if not set, the first acceptable GPU will be used (as per previous behavior).
